### PR TITLE
Add `ToImmDict(Func<T, K> selectKey, Func<T, V> selectVal)`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,9 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+          6.0.x
+          8.0.x
     - run: dotnet restore
     - run: dotnet build --no-restore
     - run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          6.0.x
-          8.0.x
+        dotnet-version: 8.0.x
     - run: dotnet restore
     - run: dotnet build --no-restore
     - run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,15 +5,13 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.x
     - run: dotnet restore
     - run: dotnet build --no-restore
     - run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            6.0.x
+            8.0.x
       - name: Build and pack
         run: |
           echo $version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            6.0.x
-            8.0.x
+          dotnet-version: 8.0.x
       - name: Build and pack
         run: |
           echo $version

--- a/Xledger.Collections.Test/TestImmDict.cs
+++ b/Xledger.Collections.Test/TestImmDict.cs
@@ -71,6 +71,34 @@ public class TestImmDict {
         Assert.ThrowsAny<NotSupportedException>(() => idict.Remove(4));
         Assert.ThrowsAny<NotSupportedException>(() => ((System.Collections.ICollection)idict).CopyTo((Array)null, 0));
     }
+
+    [Fact]
+    public void TestSelectKey() {
+        var dct = Enumerable.Range(-100, 1_000).ToDictionary(i => i);
+        var imm = Enumerable.Range(-100, 1_000).ToImmDict(i => i);
+
+        for (int i = -1000; i < 2000; ++i) {
+            Assert.Equal(dct.ContainsKey(i), imm.ContainsKey(i));
+            if (dct.TryGetValue(i, out var dctValue)) {
+                imm.TryGetValue(i, out var immValue);
+                Assert.Equal(dctValue, immValue);
+            }
+        }
+    }
+
+    [Fact]
+    public void TestSelectKeySelectValue() {
+        var dct = Enumerable.Range(-100, 1_000).ToDictionary(i => i, i => (i * i).ToString());
+        var imm = Enumerable.Range(-100, 1_000).ToImmDict(i => i, i => (i * i).ToString());
+
+        for (int i = -1000; i < 2000; ++i) {
+            Assert.Equal(dct.ContainsKey(i), imm.ContainsKey(i));
+            if (dct.TryGetValue(i, out var dctValue)) {
+                imm.TryGetValue(i, out var immValue);
+                Assert.Equal(dctValue, immValue);
+            }
+        }
+    }
 }
 
 

--- a/Xledger.Collections.Test/Xledger.Collections.Test.csproj
+++ b/Xledger.Collections.Test/Xledger.Collections.Test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Xledger.Collections.Test</PackageId>
 
-    <TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>

--- a/Xledger.Collections/Extensions.cs
+++ b/Xledger.Collections/Extensions.cs
@@ -47,6 +47,23 @@ public static class Extensions {
         };
     }
 
+    public static ImmDict<K, T> ToImmDict<T, K>(this IEnumerable<T> xs, Func<T, K> selectKey) {
+        return xs switch {
+            null => ImmDict<K, T>.Empty,
+            _ => new ImmDict<K, T>(xs.ToDictionary(selectKey)),
+        };
+    }
+
+    public static ImmDict<K, V> ToImmDict<T, K, V>(
+        this IEnumerable<T> xs,
+        Func<T, K> selectKey,
+        Func<T, V> selectVal
+    ) {
+        return xs switch {
+            null => ImmDict<K, V>.Empty,
+            _ => new ImmDict<K, V>(xs.ToDictionary(selectKey, selectVal)),
+        };
+    }
     internal static T[] ArrayOf<T>(T[] arr) {
         return (T[])arr.Clone();
     }

--- a/Xledger.Collections/Xledger.Collections.csproj
+++ b/Xledger.Collections/Xledger.Collections.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Xledger.Collections</RootNamespace>
     <AssemblyName>Xledger.Collections</AssemblyName>
 
-    <TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>


### PR DESCRIPTION
And `ToImmDict(Func<T, K> selectKey)` to simplify some conversion code instead of having to call `ToDictionary(selKey, selVal).ToImmDict()`. This avoids one dictionary copy as well.