### PR TITLE
Implements Stream.ToOwnedMemory for .NET Framework.

### DIFF
--- a/Xledger.Collections.Test/TestMemoryOwner.cs
+++ b/Xledger.Collections.Test/TestMemoryOwner.cs
@@ -23,7 +23,6 @@ public class TestMemoryOwner {
         Assert.Equal(array.AsMemory().Slice(3).Slice(1, 4), sliced2.Memory);
     }
 
-#if NET
     [Fact]
     public void TestStream_ToMemoryOwner() {
         // This length should be larger than the default GetCopyBufferSize.
@@ -31,7 +30,15 @@ public class TestMemoryOwner {
         new Random().NextBytes(array);
         var ms = new MemoryStream(array);
         using var memoryOwner = ms.ToOwnedMemory();
+#if NET
         Assert.Equal(array.AsMemory(), memoryOwner.Memory);
+#else
+        var mem = memoryOwner.Memory;
+        Assert.Equal(array.Length, mem.Length);
+        for (int i = 0; i < array.Length; ++i) {
+            Assert.Equal(array[i], mem.Span[i]);
+        }
+#endif
     }
 
     [Fact]
@@ -41,7 +48,33 @@ public class TestMemoryOwner {
         new Random().NextBytes(array);
         var ms = new MemoryStream(array);
         using var memoryOwner = await ms.ToOwnedMemoryAsync();
+#if NET
         Assert.Equal(array.AsMemory(), memoryOwner.Memory);
-    }
+#else
+        var mem = memoryOwner.Memory;
+        Assert.Equal(array.Length, mem.Length);
+        for (int i = 0; i < array.Length; ++i) {
+            Assert.Equal(array[i], mem.Span[i]);
+        }
 #endif
+    }
+
+    // Tests that reading from a stream with an unknown size does so correctly.
+    [Fact]
+    public void TestUnsizedStream_ToMemoryOwner() {
+        // This length should be larger than the default GetCopyBufferSize.
+        byte[] array = new byte[2 * 1024 * 1024 + 17];
+        new Random().NextBytes(array);
+        var ms = new UnsizedMemoryStream(array);
+        using var memoryOwner = ms.ToOwnedMemory();
+#if NET
+        Assert.Equal(array.AsMemory(), memoryOwner.Memory);
+#else
+        var mem = memoryOwner.Memory;
+        Assert.Equal(array.Length, mem.Length);
+        for (int i = 0; i < array.Length; ++i) {
+            Assert.Equal(array[i], mem.Span[i]);
+        }
+#endif
+    }
 }

--- a/Xledger.Collections/Xledger.Collections.csproj
+++ b/Xledger.Collections/Xledger.Collections.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Xledger.Collections</AssemblyName>
 
     <TargetFrameworks>net48;net8.0</TargetFrameworks>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>13.0</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
 


### PR DESCRIPTION
Additionally allocates only a single buffer when reading from a stream smaller than the max array length.