### PR TITLE
Provide slightly faster, lower memory use, safe constructors

### DIFF
--- a/Xledger.Collections.Bench/ImmArrayConstruction.cs
+++ b/Xledger.Collections.Bench/ImmArrayConstruction.cs
@@ -1,0 +1,37 @@
+namespace Xledger.Collections.Bench;
+
+[MemoryDiagnoser(displayGenColumns: false)]
+[SimpleJob(RuntimeMoniker.Net48)]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class ImmArrayConstruction {
+    [Params(300)]
+    public int Length;
+
+    [Benchmark(Baseline = true)]
+    public string[] NewArray() {
+        var arr = new string[this.Length];
+        for (int i = 0; i < arr.Length; ++i) {
+            arr[i] = Guid.NewGuid().ToString();
+        }
+        return arr;
+    }
+
+    [Benchmark]
+    public ImmArray<string> ToImmArray() {
+        var arr = new string[this.Length];
+        for (int i = 0; i < arr.Length; ++i) {
+            arr[i] = Guid.NewGuid().ToString();
+        }
+        return arr.ToImmArray();
+    }
+
+    [Benchmark]
+    public ImmArray<string> ImmArray_Build() {
+        return ImmArray.Build<string>(arr => {
+            for (int i = 0; i < arr.Length; ++i) {
+                arr[i] = Guid.NewGuid().ToString();
+            }
+        }, length: this.Length);
+    }
+}

--- a/Xledger.Collections.Bench/ImmArrayReflection.cs
+++ b/Xledger.Collections.Bench/ImmArrayReflection.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Xledger.Collections.Bench;
+
+[MemoryDiagnoser(displayGenColumns: false)]
+[SimpleJob(RuntimeMoniker.Net48)]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class ImmArrayReflection {
+    [Params(300)]
+    public int Length;
+
+    public static string[] NewArray(int length) {
+        var arr = new string[length];
+        for (int i = 0; i < arr.Length; ++i) {
+            arr[i] = Guid.NewGuid().ToString();
+        }
+        return arr;
+    }
+
+    [Benchmark(Baseline = true)]
+    public ImmArray<string> ImmArray_Build() {
+        return ImmArray.Build<string>(FillSpan, length: this.Length);
+    }
+
+    static readonly ConstructorInfo CI_NoCopy = typeof(ImmArray<string>).GetConstructor([typeof(string[])]);
+    static readonly MethodInfo MI_Build = typeof(ImmArray).GetMethods()
+        .Where(mi =>
+            mi.Name == nameof(ImmArray.Build)
+#if NET10_0_OR_GREATER
+            && mi.CustomAttributes.Where(
+                a => a.AttributeType == typeof(System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute)
+            ).Any()
+#endif
+        )
+        .Single()
+        .MakeGenericMethod(typeof(string));
+
+    static readonly MethodInfo MI_NewArray = typeof(ImmArrayReflection).GetMethod(nameof(NewArray));
+    static readonly MethodInfo MI_FillSpan = typeof(ImmArrayReflection).GetMethod(nameof(FillSpan));
+
+    static readonly Func<int, ImmArray<string>> newNoCopy = Compile_NewNoCopy();
+    static readonly Func<int, ImmArray<string>> build = Compile_Build();
+
+    public static void FillSpan(Span<string> arr) {
+        for (int i = 0; i < arr.Length; ++i) {
+            arr[i] = Guid.NewGuid().ToString();
+        }
+    }
+
+    [Benchmark]
+    public ImmArray<string> DynInvoke_NewNoCopy() {
+        return (ImmArray<string>)CI_NoCopy.Invoke([NewArray(this.Length)]);
+    }
+
+    [Benchmark]
+    public ImmArray<string> NewNoCopy() {
+        return new ImmArray<string>(NewArray(this.Length));
+    }
+
+    static Func<int, ImmArray<string>> Compile_NewNoCopy() {
+        var pi_length = Expression.Parameter(typeof(int), "length");
+        var newImmArray =
+            Expression.New(CI_NoCopy,
+                Expression.Call(MI_NewArray, pi_length));
+        var fn = Expression.Lambda<Func<int, ImmArray<string>>>(newImmArray, tailCall: false, pi_length).Compile();
+        return fn;
+    }
+
+    static Func<int, ImmArray<string>> Compile_Build() {
+        var pi_length = Expression.Parameter(typeof(int), "length");
+#if NET10_0_OR_GREATER
+        var fillSpanDelegate = MI_FillSpan.CreateDelegate<Action<Span<string>>>();
+#else
+        var fillSpanDelegate = MI_FillSpan.CreateDelegate(typeof(ImmArray.FillSpan<string>));
+#endif
+        var newImmArray = Expression.Call(MI_Build, Expression.Constant(fillSpanDelegate), pi_length);
+        var fn = Expression.Lambda<Func<int, ImmArray<string>>>(newImmArray, tailCall: false, pi_length).Compile();
+        return fn;
+    }
+
+    [Benchmark]
+    public ImmArray<string> Expr_NewNoCopy() {
+        return newNoCopy(this.Length);
+    }
+
+    [Benchmark]
+    public ImmArray<string> Expr_Build() {
+        return build(this.Length);
+    }
+}

--- a/Xledger.Collections.Bench/ImmArrayReflection.cs
+++ b/Xledger.Collections.Bench/ImmArrayReflection.cs
@@ -25,7 +25,11 @@ public class ImmArrayReflection {
         return ImmArray.Build<string>(FillSpan, length: this.Length);
     }
 
-    static readonly ConstructorInfo CI_NoCopy = typeof(ImmArray<string>).GetConstructor([typeof(string[])]);
+    static readonly ConstructorInfo CI_NoCopy = typeof(ImmArray<string>).GetConstructor(
+        BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.ExactBinding,
+        binder: null,
+        [typeof(string[])],
+        modifiers: null);
     static readonly MethodInfo MI_Build = typeof(ImmArray).GetMethods()
         .Where(mi =>
             mi.Name == nameof(ImmArray.Build)

--- a/Xledger.Collections.Bench/ImmDictConstruction.cs
+++ b/Xledger.Collections.Bench/ImmDictConstruction.cs
@@ -1,0 +1,40 @@
+namespace Xledger.Collections.Bench;
+
+[MemoryDiagnoser(displayGenColumns: false)]
+[SimpleJob(RuntimeMoniker.Net48)]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class ImmDictConstruction {
+    [Params(0, 300)]
+    public int Capacity;
+
+    [Params(300, 500)]
+    public int Count;
+
+    [Benchmark(Baseline = true)]
+    public Dictionary<string, int> NewDictionary() {
+        var dict = new Dictionary<string, int>(this.Capacity);
+        for (int i = 0; i < this.Count; ++i) {
+            dict.Add(Guid.NewGuid().ToString(), i);
+        }
+        return dict;
+    }
+
+    [Benchmark]
+    public ImmDict<string, int> ToImmDict() {
+        var dict = new Dictionary<string, int>(this.Capacity);
+        for (int i = 0; i < this.Count; ++i) {
+            dict.Add(Guid.NewGuid().ToString(), i);
+        }
+        return dict.ToImmDict();
+    }
+
+    [Benchmark]
+    public ImmDict<string, int> ImmDict_Build() {
+        return ImmDict.Build<string, int>(dict => {
+            for (int i = 0; i < this.Count; ++i) {
+                dict.Add(Guid.NewGuid().ToString(), i);
+            }
+        }, capacity: this.Capacity);
+    }
+}

--- a/Xledger.Collections.Bench/ImmDictReflection.cs
+++ b/Xledger.Collections.Bench/ImmDictReflection.cs
@@ -1,0 +1,101 @@
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Xledger.Collections.Bench;
+
+[MemoryDiagnoser(displayGenColumns: false)]
+[SimpleJob(RuntimeMoniker.Net48)]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class ImmDictReflection {
+    [Params(0, 300)]
+    public int Capacity;
+
+    [Params(300, 500)]
+    public int Count;
+
+    public static Dictionary<string, int> NewDictionary(int capacity, int count) {
+        var dict = new Dictionary<string, int>(capacity);
+        for (int i = 0; i < count; ++i) {
+            dict.Add(Guid.NewGuid().ToString(), i);
+        }
+        return dict;
+    }
+
+    public static ImmDict.BuildDict<string, int> MakeFillDict(int count) {
+        return (ImmDict.DictBuilder<string, int> dict) => {
+            for (int i = 0; i < count; ++i) {
+                dict.Add(Guid.NewGuid().ToString(), i);
+            }
+        };
+    }
+
+    [Benchmark(Baseline = true)]
+    public ImmDict<string, int> ImmDict_Build() {
+        return ImmDict.Build<string, int>(MakeFillDict(this.Count), capacity: this.Capacity);
+    }
+
+    static readonly ConstructorInfo CI_NoCopy = typeof(ImmDict<string, int>).GetConstructor(
+        BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.ExactBinding,
+        binder: null,
+        [typeof(Dictionary<string, int>)],
+        modifiers: null);
+    static readonly MethodInfo MI_Build = typeof(ImmDict).GetMethods()
+        .Where(mi => mi.Name == nameof(ImmDict.Build))
+        .Last()
+        .MakeGenericMethod(typeof(string), typeof(int));
+
+    static readonly MethodInfo MI_NewDictionary = typeof(ImmDictReflection).GetMethod(nameof(NewDictionary));
+    static readonly MethodInfo MI_MakeFillDict = typeof(ImmDictReflection).GetMethod(nameof(MakeFillDict));
+
+    static readonly Func<int, int, ImmDict<string, int>> newNoCopy = Compile_NewNoCopy();
+    static readonly Func<int, int, ImmDict<string, int>> build = Compile_Build();
+
+    [Benchmark]
+    public ImmDict<string, int> DynInvoke_NewNoCopy() {
+        return (ImmDict<string, int>)CI_NoCopy.Invoke([NewDictionary(this.Capacity, this.Count)]);
+    }
+
+    [Benchmark]
+    public ImmDict<string, int> NewNoCopy() {
+        return new ImmDict<string, int>(NewDictionary(this.Capacity, this.Count));
+    }
+
+    static Func<int, int, ImmDict<string, int>> Compile_NewNoCopy() {
+        var pi_capacity = Expression.Parameter(typeof(int), "capacity");
+        var pi_count = Expression.Parameter(typeof(int), "count");
+        var newImmSet =
+            Expression.New(CI_NoCopy,
+                Expression.Call(MI_NewDictionary, pi_capacity, pi_count));
+        var fn = Expression.Lambda<Func<int, int, ImmDict<string, int>>>(
+            newImmSet,
+            tailCall: false,
+            pi_capacity,
+            pi_count).Compile();
+        return fn;
+    }
+
+    static Func<int, int, ImmDict<string, int>> Compile_Build() {
+        var pi_capacity = Expression.Parameter(typeof(int), "capacity");
+        var pi_count = Expression.Parameter(typeof(int), "count");
+        var fillSetDelegate = Expression.Call(MI_MakeFillDict, pi_count);
+        var newImmSet = Expression.Call(MI_Build, fillSetDelegate, pi_capacity, Expression.Constant(false));
+        var fn = Expression.Lambda<Func<int, int, ImmDict<string, int>>>(
+            newImmSet,
+            tailCall: false,
+            pi_capacity,
+            pi_count).Compile();
+        return fn;
+    }
+
+    [Benchmark]
+    public ImmDict<string, int> Expr_NewNoCopy() {
+        return newNoCopy(this.Capacity, this.Count);
+    }
+
+    [Benchmark]
+    public ImmDict<string, int> Expr_Build() {
+        return build(this.Capacity, this.Count);
+    }
+}

--- a/Xledger.Collections.Bench/ImmSetConstruction.cs
+++ b/Xledger.Collections.Bench/ImmSetConstruction.cs
@@ -1,0 +1,40 @@
+namespace Xledger.Collections.Bench;
+
+[MemoryDiagnoser(displayGenColumns: false)]
+[SimpleJob(RuntimeMoniker.Net48)]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class ImmSetConstruction {
+    [Params(0, 300)]
+    public int Capacity;
+
+    [Params(300, 500)]
+    public int Count;
+
+    [Benchmark(Baseline = true)]
+    public HashSet<string> NewHashSet() {
+        var set = new HashSet<string>(this.Capacity);
+        for (int i = 0; i < this.Count; ++i) {
+            set.Add(Guid.NewGuid().ToString());
+        }
+        return set;
+    }
+
+    [Benchmark]
+    public ImmSet<string> ToImmSet() {
+        var set = new HashSet<string>(this.Capacity);
+        for (int i = 0; i < this.Count; ++i) {
+            set.Add(Guid.NewGuid().ToString());
+        }
+        return set.ToImmSet();
+    }
+
+    [Benchmark]
+    public ImmSet<string> ImmSet_Build() {
+        return ImmSet.Build<string>(set => {
+            for (int i = 0; i < this.Count; ++i) {
+                set.Add(Guid.NewGuid().ToString());
+            }
+        }, capacity: this.Capacity);
+    }
+}

--- a/Xledger.Collections.Bench/ImmSetReflection.cs
+++ b/Xledger.Collections.Bench/ImmSetReflection.cs
@@ -1,0 +1,101 @@
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Xledger.Collections.Bench;
+
+[MemoryDiagnoser(displayGenColumns: false)]
+[SimpleJob(RuntimeMoniker.Net48)]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class ImmSetReflection {
+    [Params(0, 300)]
+    public int Capacity;
+
+    [Params(300, 500)]
+    public int Count;
+
+    public static HashSet<string> NewHashSet(int capacity, int count) {
+        var set = new HashSet<string>(capacity);
+        for (int i = 0; i < count; ++i) {
+            set.Add(Guid.NewGuid().ToString());
+        }
+        return set;
+    }
+
+    public static ImmSet.BuildSet<string> MakeFillSet(int count) {
+        return (ImmSet.SetBuilder<string> set) => {
+            for (int i = 0; i < count; ++i) {
+                set.Add(Guid.NewGuid().ToString());
+            }
+        };
+    }
+
+    [Benchmark(Baseline = true)]
+    public ImmSet<string> ImmSet_Build() {
+        return ImmSet.Build<string>(MakeFillSet(this.Count), capacity: this.Capacity);
+    }
+
+    static readonly ConstructorInfo CI_NoCopy = typeof(ImmSet<string>).GetConstructor(
+        BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.ExactBinding,
+        binder: null,
+        [typeof(HashSet<string>)],
+        modifiers: null);
+    static readonly MethodInfo MI_Build = typeof(ImmSet).GetMethods()
+        .Where(mi => mi.Name == nameof(ImmSet.Build))
+        .Last()
+        .MakeGenericMethod(typeof(string));
+
+    static readonly MethodInfo MI_NewHashSet = typeof(ImmSetReflection).GetMethod(nameof(NewHashSet));
+    static readonly MethodInfo MI_MakeFillSet = typeof(ImmSetReflection).GetMethod(nameof(MakeFillSet));
+
+    static readonly Func<int, int, ImmSet<string>> newNoCopy = Compile_NewNoCopy();
+    static readonly Func<int, int, ImmSet<string>> build = Compile_Build();
+
+    [Benchmark]
+    public ImmSet<string> DynInvoke_NewNoCopy() {
+        return (ImmSet<string>)CI_NoCopy.Invoke([NewHashSet(this.Capacity, this.Count)]);
+    }
+
+    [Benchmark]
+    public ImmSet<string> NewNoCopy() {
+        return new ImmSet<string>(NewHashSet(this.Capacity, this.Count));
+    }
+
+    static Func<int, int, ImmSet<string>> Compile_NewNoCopy() {
+        var pi_capacity = Expression.Parameter(typeof(int), "capacity");
+        var pi_count = Expression.Parameter(typeof(int), "count");
+        var newImmSet =
+            Expression.New(CI_NoCopy,
+                Expression.Call(MI_NewHashSet, pi_capacity, pi_count));
+        var fn = Expression.Lambda<Func<int, int, ImmSet<string>>>(
+            newImmSet,
+            tailCall: false,
+            pi_capacity,
+            pi_count).Compile();
+        return fn;
+    }
+
+    static Func<int, int, ImmSet<string>> Compile_Build() {
+        var pi_capacity = Expression.Parameter(typeof(int), "capacity");
+        var pi_count = Expression.Parameter(typeof(int), "count");
+        var fillSetDelegate = Expression.Call(MI_MakeFillSet, pi_count);
+        var newImmSet = Expression.Call(MI_Build, fillSetDelegate, pi_capacity, Expression.Constant(false));
+        var fn = Expression.Lambda<Func<int, int, ImmSet<string>>>(
+            newImmSet,
+            tailCall: false,
+            pi_capacity,
+            pi_count).Compile();
+        return fn;
+    }
+
+    [Benchmark]
+    public ImmSet<string> Expr_NewNoCopy() {
+        return newNoCopy(this.Capacity, this.Count);
+    }
+
+    [Benchmark]
+    public ImmSet<string> Expr_Build() {
+        return build(this.Capacity, this.Count);
+    }
+}

--- a/Xledger.Collections.Bench/Program.cs
+++ b/Xledger.Collections.Bench/Program.cs
@@ -1,0 +1,3 @@
+BenchmarkDotNet.Running.BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/Xledger.Collections.Bench/Usings.cs
+++ b/Xledger.Collections.Bench/Usings.cs
@@ -1,0 +1,6 @@
+global using BenchmarkDotNet;
+global using BenchmarkDotNet.Attributes;
+global using BenchmarkDotNet.Jobs;
+global using System;
+global using System.Collections.Generic;
+global using Xledger.Collections;

--- a/Xledger.Collections.Bench/Xledger.Collections.Bench.csproj
+++ b/Xledger.Collections.Bench/Xledger.Collections.Bench.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net48;net8.0;net10.0</TargetFrameworks>
+    <LangVersion>14.0</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="BenchmarkDotNet.Artifacts\**" />
+    <EmbeddedResource Remove="BenchmarkDotNet.Artifacts\**" />
+    <None Remove="BenchmarkDotNet.Artifacts\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Xledger.Collections\Xledger.Collections.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+</Project>

--- a/Xledger.Collections.Test/TestImmArray.cs
+++ b/Xledger.Collections.Test/TestImmArray.cs
@@ -215,6 +215,20 @@ public class TestImmArray {
 
         var a = ImmArray.Of<int[]>(new int[] { 1 });
         Assert.Equal(typeof(ImmArray<int[]>), a.GetType());
+
+        var b = ImmArray.Of(new ImplicitIntArray(1));
+        Assert.Equal(typeof(ImmArray<ImplicitIntArray>), b.GetType());
+
+        var c = ImmArray.Of(new ExplicitIntArray(1));
+        Assert.Equal(typeof(ImmArray<ExplicitIntArray>), c.GetType());
+    }
+
+    public record ImplicitIntArray(int i) {
+        public static implicit operator int[](ImplicitIntArray arr) => [arr.i];
+    }
+
+    public record ExplicitIntArray(int i) {
+        public static explicit operator int[](ExplicitIntArray arr) => [arr.i];
     }
 }
 

--- a/Xledger.Collections.Test/TestImmArray.cs
+++ b/Xledger.Collections.Test/TestImmArray.cs
@@ -199,5 +199,22 @@ public class TestImmArray {
             Assert.Equal(arr[i], imm[i]);
         }
     }
+
+    [Fact]
+    public void TestOf() {
+        var x = ImmArray.Of(new int[] { 1 });
+        Assert.Equal(typeof(ImmArray<int>), x.GetType());
+
+        var y = ImmArray.Of(1);
+        Assert.Equal(typeof(ImmArray<int>), y.GetType());
+
+#if NET
+        var z = ImmArray.Of((ReadOnlySpan<int>)[1]);
+        Assert.Equal(typeof(ImmArray<int>), z.GetType());
+#endif
+
+        var a = ImmArray.Of<int[]>(new int[] { 1 });
+        Assert.Equal(typeof(ImmArray<int[]>), a.GetType());
+    }
 }
 

--- a/Xledger.Collections.Test/TestImmArray.cs
+++ b/Xledger.Collections.Test/TestImmArray.cs
@@ -187,7 +187,7 @@ public class TestImmArray {
     [Fact]
     public void TestNewSized() {
         var arr = Enumerable.Range(-1, 100).Select(i => $"{i}: {2 * i}").ToArray();
-        var imm = ImmArray.NewSized<string>(100, static span => {
+        var imm = ImmArray.New<string>(100, static span => {
             for (int i = 0; i < span.Length; ++i) {
                 var j = i - 1;
                 span[i] = $"{j}: {2 * j}";

--- a/Xledger.Collections.Test/TestImmArray.cs
+++ b/Xledger.Collections.Test/TestImmArray.cs
@@ -187,12 +187,12 @@ public class TestImmArray {
     [Fact]
     public void TestNewSized() {
         var arr = Enumerable.Range(-1, 100).Select(i => $"{i}: {2 * i}").ToArray();
-        var imm = ImmArray.New<string>(100, static span => {
+        var imm = ImmArray.Build<string>(static span => {
             for (int i = 0; i < span.Length; ++i) {
                 var j = i - 1;
                 span[i] = $"{j}: {2 * j}";
             }
-        });
+        }, length: 100);
         Assert.Equal(arr.Length, imm.Length);
         Assert.Equal("-1: -2", imm[0]);
         for (int i = 0; i < imm.Length; ++i) {

--- a/Xledger.Collections.Test/TestImmArray.cs
+++ b/Xledger.Collections.Test/TestImmArray.cs
@@ -183,5 +183,21 @@ public class TestImmArray {
             Assert.Equal(arr[i], imm[i]);
         }
     }
+
+    [Fact]
+    public void TestNewSized() {
+        var arr = Enumerable.Range(-1, 100).Select(i => $"{i}: {2 * i}").ToArray();
+        var imm = ImmArray.NewSized<string>(100, static span => {
+            for (int i = 0; i < span.Length; ++i) {
+                var j = i - 1;
+                span[i] = $"{j}: {2 * j}";
+            }
+        });
+        Assert.Equal(arr.Length, imm.Length);
+        Assert.Equal("-1: -2", imm[0]);
+        for (int i = 0; i < imm.Length; ++i) {
+            Assert.Equal(arr[i], imm[i]);
+        }
+    }
 }
 

--- a/Xledger.Collections.Test/TestImmDict.cs
+++ b/Xledger.Collections.Test/TestImmDict.cs
@@ -103,11 +103,11 @@ public class TestImmDict {
     [Fact]
     public void TestNewSized() {
         var dct = Enumerable.Range(-100, 1_000).ToDictionary(i => i, i => (i * i).ToString());
-        var imm = ImmDict.New<int, string>(1_000, dict => {
+        var imm = ImmDict.Build<int, string>(dict => {
             for (int i = -100, top = 1000 - 100; i < top; ++i) {
                 dict.Add(i, (i * i).ToString());
             }
-        });
+        }, capacity: 1_000);
 
         for (int i = -1000; i < 2000; ++i) {
             Assert.Equal(dct.ContainsKey(i), imm.ContainsKey(i));

--- a/Xledger.Collections.Test/TestImmDict.cs
+++ b/Xledger.Collections.Test/TestImmDict.cs
@@ -99,6 +99,24 @@ public class TestImmDict {
             }
         }
     }
+
+    [Fact]
+    public void TestNewSized() {
+        var dct = Enumerable.Range(-100, 1_000).ToDictionary(i => i, i => (i * i).ToString());
+        var imm = ImmDict.New<int, string>(1_000, dict => {
+            for (int i = -100, top = 1000 - 100; i < top; ++i) {
+                dict.Add(i, (i * i).ToString());
+            }
+        });
+
+        for (int i = -1000; i < 2000; ++i) {
+            Assert.Equal(dct.ContainsKey(i), imm.ContainsKey(i));
+            if (dct.TryGetValue(i, out var dctValue)) {
+                imm.TryGetValue(i, out var immValue);
+                Assert.Equal(dctValue, immValue);
+            }
+        }
+    }
 }
 
 

--- a/Xledger.Collections.Test/TestImmSet.cs
+++ b/Xledger.Collections.Test/TestImmSet.cs
@@ -116,6 +116,14 @@ public class TestImmSet{
             Assert.Contains(i, (ISet<int>)imm);
         }
     }
+
+    [Fact]
+    public void TestNew() {
+        var imm = Enumerable.Range(-10, 21).ToImmSet(Math.Abs);
+        var imm2 = ImmSet.New<int>(set => set.AddRange(Enumerable.Range(-10, 21).Select(Math.Abs)));
+        Assert.Equal(11, imm.Count);
+        Assert.Equivalent(imm, imm2);
+    }
 }
 
 

--- a/Xledger.Collections.Test/TestImmSet.cs
+++ b/Xledger.Collections.Test/TestImmSet.cs
@@ -120,7 +120,7 @@ public class TestImmSet{
     [Fact]
     public void TestNew() {
         var imm = Enumerable.Range(-10, 21).ToImmSet(Math.Abs);
-        var imm2 = ImmSet.New<int>(set => set.AddRange(Enumerable.Range(-10, 21).Select(Math.Abs)));
+        var imm2 = ImmSet.Build<int>(set => set.UnionWith(Enumerable.Range(-10, 21).Select(Math.Abs)));
         Assert.Equal(11, imm.Count);
         Assert.Equivalent(imm, imm2);
     }

--- a/Xledger.Collections.Test/Xledger.Collections.Test.csproj
+++ b/Xledger.Collections.Test/Xledger.Collections.Test.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <PackageId>Xledger.Collections.Test</PackageId>
 
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
-    <LangVersion>12.0</LangVersion>
+    <TargetFrameworks>net48;net8.0;net10.0</TargetFrameworks>
+    <LangVersion>14.0</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/Xledger.Collections.Test/Xledger.Collections.Test.csproj
+++ b/Xledger.Collections.Test/Xledger.Collections.Test.csproj
@@ -38,6 +38,10 @@
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.11.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='net10.0'">
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="10.0.3" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Xledger.Collections\Xledger.Collections.csproj" />
   </ItemGroup>

--- a/Xledger.Collections.sln
+++ b/Xledger.Collections.sln
@@ -6,6 +6,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xledger.Collections", "Xled
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xledger.Collections.Test", "Xledger.Collections.Test\Xledger.Collections.Test.csproj", "{312CFF25-A5F7-4ADE-9866-3B3F6319BBEE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xledger.Collections.Bench", "Xledger.Collections.Bench\Xledger.Collections.Bench.csproj", "{EE44BC4F-C699-6623-9FA2-444D857AE154}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +22,10 @@ Global
 		{312CFF25-A5F7-4ADE-9866-3B3F6319BBEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{312CFF25-A5F7-4ADE-9866-3B3F6319BBEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{312CFF25-A5F7-4ADE-9866-3B3F6319BBEE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE44BC4F-C699-6623-9FA2-444D857AE154}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE44BC4F-C699-6623-9FA2-444D857AE154}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE44BC4F-C699-6623-9FA2-444D857AE154}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE44BC4F-C699-6623-9FA2-444D857AE154}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Xledger.Collections/AssemblyInfo.cs
+++ b/Xledger.Collections/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Xledger.Collections.Bench")]
 [assembly: InternalsVisibleTo("Xledger.Collections.Test")]
 [assembly: InternalsVisibleTo("LINQPadQuery")]

--- a/Xledger.Collections/AssemblyInfo.cs
+++ b/Xledger.Collections/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Xledger.Collections.Test")]
+[assembly: InternalsVisibleTo("LINQPadQuery")]

--- a/Xledger.Collections/Extensions.cs
+++ b/Xledger.Collections/Extensions.cs
@@ -119,11 +119,7 @@ public static class Extensions {
     }
 
     internal static T[] ArrayOf<T>(IEnumerable<T> xs) {
-        var lst = new List<T>();
-        foreach (var x in xs) {
-            lst.Add(x);
-        }
-        return lst.ToArray();
+        return xs.ToArray();
     }
 
     internal static U[] ArrayOf<T, U>(int n, IEnumerable<T> xs, Func<T, U> f) {

--- a/Xledger.Collections/Extensions.cs
+++ b/Xledger.Collections/Extensions.cs
@@ -28,6 +28,10 @@ public static class Extensions {
     }
 #endif
 
+    public static ImmArray<T> ToImmArray<T>(this Span<T> xs) {
+        return new ImmArray<T>(xs.ToArray());
+    }
+
     public static ImmSet<T> ToImmSet<T>(this IEnumerable<T> xs) {
         return xs switch {
             null => ImmSet<T>.Empty,
@@ -45,9 +49,21 @@ public static class Extensions {
 
 #if NET
     public static ImmSet<T> ToImmSet<T>(this ReadOnlySpan<T> xs) {
-        return new ImmSet<T>(xs.ToArray());
+        var set = new HashSet<T>(xs.Length);
+        foreach (var x in xs) {
+            set.Add(x);
+        }
+        return new ImmSet<T>(set);
     }
 #endif
+
+    public static ImmSet<T> ToImmSet<T>(this Span<T> xs) {
+        var set = new HashSet<T>(xs.Length);
+        foreach (var x in xs) {
+            set.Add(x);
+        }
+        return new ImmSet<T>(set);
+    }
 
     public static ImmDict<K, V> ToImmDict<K, V>(this IEnumerable<KeyValuePair<K, V>> xs) {
         return xs switch {

--- a/Xledger.Collections/ImmArray.cs
+++ b/Xledger.Collections/ImmArray.cs
@@ -12,17 +12,13 @@ public static class ImmArray {
 #else
     public static ImmArray<T> Of<T>(ReadOnlySpan<T> span) {
 #endif
-        return span.ToImmArray();
+        return new ImmArray<T>(span);
     }
 #endif
 
-    public static ImmArray<T> Of<T>(Span<T> span) {
-        return span.ToImmArray();
-    }
-
 #if NET10_0_OR_GREATER
     [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-    public static ImmArray<T> New<T>(int length, Action<Span<T>> fill) {
+    public static ImmArray<T> Build<T>(Action<Span<T>> fill, int length) {
         var data = new T[length];
         fill(data);
         return new ImmArray<T>(data);
@@ -31,7 +27,7 @@ public static class ImmArray {
 
     public delegate void FillSpan<T>(Span<T> span);
 
-    public static ImmArray<T> New<T>(int length, FillSpan<T> fill) {
+    public static ImmArray<T> Build<T>(FillSpan<T> fill, int length) {
         var data = new T[length];
         fill(data);
         return new ImmArray<T>(data);
@@ -79,6 +75,13 @@ public sealed class ImmArray<T> : IReadOnlyList<T>, IEquatable<ImmArray<T>>, ILi
         } else {
             this.data = Extensions.ArrayOf(data);
         }
+    }
+
+    /// <summary>
+    /// Constructs an ImmArray by copying the span's contents.
+    /// </summary>
+    public ImmArray(params ReadOnlySpan<T> data) {
+        this.data = data.ToArray();
     }
 
     public ReadOnlySpan<T> Span => this.data;

--- a/Xledger.Collections/ImmArray.cs
+++ b/Xledger.Collections/ImmArray.cs
@@ -10,6 +10,10 @@ public static class ImmArray {
         return span.ToImmArray();
     }
 #endif
+
+    public static ImmArray<T> Of<T>(Span<T> span) {
+        return span.ToImmArray();
+    }
 }
 
 [Serializable]

--- a/Xledger.Collections/ImmArray.cs
+++ b/Xledger.Collections/ImmArray.cs
@@ -6,13 +6,93 @@ public static class ImmArray {
     }
 
 #if NET
+#if NET10_0_OR_GREATER
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static ImmArray<T> Of<T>(params ReadOnlySpan<T> span) {
+#else
     public static ImmArray<T> Of<T>(ReadOnlySpan<T> span) {
+#endif
         return span.ToImmArray();
     }
 #endif
 
     public static ImmArray<T> Of<T>(Span<T> span) {
         return span.ToImmArray();
+    }
+
+#if NET10_0_OR_GREATER
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static ImmArray<T> NewSized<T>(int length, Action<Span<T>> fill) {
+        var data = new T[length];
+        fill(data);
+        return new ImmArray<T>(data);
+    }
+#endif
+
+    public delegate void FillSpan<T>(Span<T> span);
+
+    public static ImmArray<T> NewSized<T>(int length, FillSpan<T> fill) {
+        var data = new T[length];
+        fill(data);
+        return new ImmArray<T>(data);
+    }
+
+#if NET
+    public static ImmArray<T> NewSized<T, Ctx>(int length, Ctx ctx, System.Buffers.SpanAction<T, Ctx> fill) {
+        var data = new T[length];
+        fill(data, ctx);
+        return new ImmArray<T>(data);
+    }
+#endif
+
+    public readonly ref struct ListBuilder<T> {
+        readonly List<T> data;
+
+        public ListBuilder() { this.data = []; }
+        public ListBuilder(int capacity) { this.data = new(capacity); }
+
+        public int Count => this.data.Count;
+
+        public T this[int index] {
+            get => this.data[index];
+            set => this.data[index] = value;
+        }
+
+        public void Add(T item) => this.data.Add(item);
+
+        public void AddRange(IEnumerable<T> items) => this.data.AddRange(items);
+
+        internal T[] ToArray() => this.data.ToArray();
+    }
+
+#if NET10_0_OR_GREATER
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static ImmArray<T> New<T>(Action<ListBuilder<T>> fill) {
+        var list = new ListBuilder<T>();
+        fill(list);
+        return new ImmArray<T>(list.ToArray());
+    }
+
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static ImmArray<T> New<T>(int capacity, Action<ListBuilder<T>> fill) {
+        var list = new ListBuilder<T>(capacity);
+        fill(list);
+        return new ImmArray<T>(list.ToArray());
+    }
+#endif
+
+    public delegate void BuildList<T>(ListBuilder<T> list);
+
+    public static ImmArray<T> New<T>(BuildList<T> fill) {
+        var list = new ListBuilder<T>();
+        fill(list);
+        return new ImmArray<T>(list.ToArray());
+    }
+
+    public static ImmArray<T> New<T>(int capacity, BuildList<T> fill) {
+        var list = new ListBuilder<T>(capacity);
+        fill(list);
+        return new ImmArray<T>(list.ToArray());
     }
 }
 

--- a/Xledger.Collections/ImmArray.cs
+++ b/Xledger.Collections/ImmArray.cs
@@ -22,7 +22,7 @@ public static class ImmArray {
 
 #if NET10_0_OR_GREATER
     [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-    public static ImmArray<T> NewSized<T>(int length, Action<Span<T>> fill) {
+    public static ImmArray<T> New<T>(int length, Action<Span<T>> fill) {
         var data = new T[length];
         fill(data);
         return new ImmArray<T>(data);
@@ -31,19 +31,11 @@ public static class ImmArray {
 
     public delegate void FillSpan<T>(Span<T> span);
 
-    public static ImmArray<T> NewSized<T>(int length, FillSpan<T> fill) {
+    public static ImmArray<T> New<T>(int length, FillSpan<T> fill) {
         var data = new T[length];
         fill(data);
         return new ImmArray<T>(data);
     }
-
-#if NET
-    public static ImmArray<T> NewSized<T, Ctx>(int length, Ctx ctx, System.Buffers.SpanAction<T, Ctx> fill) {
-        var data = new T[length];
-        fill(data, ctx);
-        return new ImmArray<T>(data);
-    }
-#endif
 }
 
 [Serializable]

--- a/Xledger.Collections/ImmArray.cs
+++ b/Xledger.Collections/ImmArray.cs
@@ -44,56 +44,6 @@ public static class ImmArray {
         return new ImmArray<T>(data);
     }
 #endif
-
-    public readonly ref struct ListBuilder<T> {
-        readonly List<T> data;
-
-        public ListBuilder() { this.data = []; }
-        public ListBuilder(int capacity) { this.data = new(capacity); }
-
-        public int Count => this.data.Count;
-
-        public T this[int index] {
-            get => this.data[index];
-            set => this.data[index] = value;
-        }
-
-        public void Add(T item) => this.data.Add(item);
-
-        public void AddRange(IEnumerable<T> items) => this.data.AddRange(items);
-
-        internal T[] ToArray() => this.data.ToArray();
-    }
-
-#if NET10_0_OR_GREATER
-    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-    public static ImmArray<T> New<T>(Action<ListBuilder<T>> fill) {
-        var list = new ListBuilder<T>();
-        fill(list);
-        return new ImmArray<T>(list.ToArray());
-    }
-
-    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-    public static ImmArray<T> New<T>(int capacity, Action<ListBuilder<T>> fill) {
-        var list = new ListBuilder<T>(capacity);
-        fill(list);
-        return new ImmArray<T>(list.ToArray());
-    }
-#endif
-
-    public delegate void BuildList<T>(ListBuilder<T> list);
-
-    public static ImmArray<T> New<T>(BuildList<T> fill) {
-        var list = new ListBuilder<T>();
-        fill(list);
-        return new ImmArray<T>(list.ToArray());
-    }
-
-    public static ImmArray<T> New<T>(int capacity, BuildList<T> fill) {
-        var list = new ListBuilder<T>(capacity);
-        fill(list);
-        return new ImmArray<T>(list.ToArray());
-    }
 }
 
 [Serializable]

--- a/Xledger.Collections/ImmDict.cs
+++ b/Xledger.Collections/ImmDict.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Xledger.Collections;
 
 public static class ImmDict {
@@ -9,13 +11,6 @@ public static class ImmDict {
         return arr.ToImmDict();
     }
 
-    //#if NET10_0_OR_GREATER
-    //    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-    //    public static ImmDict<K, V> Of<K, V>(params ReadOnlySpan<(K, V)> span) {
-    //        return span.ToImmDict();
-    //    }
-    //#endif
-
     public readonly ref struct DictBuilder<K, V> {
         internal readonly Dictionary<K, V> data;
 
@@ -24,6 +19,17 @@ public static class ImmDict {
 
         public int Count => this.data.Count;
 
+        public bool ContainsKey(K key) => this.data.ContainsKey(key);
+
+        public bool ContainsValue(V value) => this.data.ContainsValue(value);
+
+#if NET
+        public bool TryGetValue(K key, [MaybeNullWhen(false)] out V value) =>
+#else
+        public bool TryGetValue(K key, out V value) =>
+#endif
+            this.data.TryGetValue(key, out value);
+
         public V this[K key] {
             get => this.data[key];
             set => this.data[key] = value;
@@ -31,38 +37,63 @@ public static class ImmDict {
 
         public void Add(K key, V value) => this.data.Add(key, value);
 
-        //public void Insert(K key, V value) => this.xs.A
-
-        //public void AddRange(IEnumerable<T> ys) => this.xs.AddRange(ys);
+        public bool TryAdd(K key, V value) {
+#if NET
+            return this.data.TryAdd(key, value);
+#else
+            if (this.data.ContainsKey(key)) {
+                return false;
+            } else {
+                this.data.Add(key, value);
+                return true;
+            }
+#endif
+        }
     }
 
 #if NET10_0_OR_GREATER
+    /// <summary>
+    /// Safely and quickly build a new ImmDict without having to copy an existing dictionary.
+    /// </summary>
+    /// <param name="fill">Delegate to call to build out the internal dictionary</param>
+    /// <param name="capacity">Default capacity used to instantiate the dictionary</param>
+    /// <param name="trimExcess">If true, TrimExcess is called. Ignored on .NET Framework.</param>
     [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-    public static ImmDict<K, V> New<K, V>(Action<DictBuilder<K, V>> fill) {
-        var dict = new DictBuilder<K, V>();
-        fill(dict);
-        return new ImmDict<K, V>(dict.data);
-    }
-
-    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-    public static ImmDict<K, V> New<K, V>(int capacity, Action<DictBuilder<K, V>> fill) {
+    public static ImmDict<K, V> Build<K, V>(Action<DictBuilder<K, V>> fill,
+        int capacity = 0,
+        bool trimExcess = false
+    ) {
         var dict = new DictBuilder<K, V>(capacity);
         fill(dict);
+#if NET
+        if (trimExcess) {
+            dict.data.TrimExcess();
+        }
+#endif
         return new ImmDict<K, V>(dict.data);
     }
 #endif
 
     public delegate void BuildDict<K, V>(DictBuilder<K, V> dict);
 
-    public static ImmDict<K, V> New<K, V>(BuildDict<K, V> fill) {
-        var dict = new DictBuilder<K, V>();
-        fill(dict);
-        return new ImmDict<K, V>(dict.data);
-    }
-
-    public static ImmDict<K, V> New<K, V>(int capacity, BuildDict<K, V> fill) {
+    /// <summary>
+    /// Safely and quickly build a new ImmDict without having to copy an existing dictionary.
+    /// </summary>
+    /// <param name="fill">Delegate to call to build out the internal dictionary</param>
+    /// <param name="capacity">Default capacity used to instantiate the dictionary</param>
+    /// <param name="trimExcess">If true, TrimExcess is called. Ignored on .NET Framework.</param>
+    public static ImmDict<K, V> Build<K, V>(
+        BuildDict<K, V> fill,
+        int capacity = 0,
+        bool trimExcess = false
+    ) {
         var dict = new DictBuilder<K, V>(capacity);
         fill(dict);
+#if NET
+        if (trimExcess) {
+            dict.data.TrimExcess();
+        }
+#endif
         return new ImmDict<K, V>(dict.data);
     }
 }

--- a/Xledger.Collections/ImmDict.cs
+++ b/Xledger.Collections/ImmDict.cs
@@ -8,6 +8,63 @@ public static class ImmDict {
     public static ImmDict<K, V> Of<K, V>(params (K, V)[] arr) {
         return arr.ToImmDict();
     }
+
+    //#if NET10_0_OR_GREATER
+    //    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    //    public static ImmDict<K, V> Of<K, V>(params ReadOnlySpan<(K, V)> span) {
+    //        return span.ToImmDict();
+    //    }
+    //#endif
+
+    public readonly ref struct DictBuilder<K, V> {
+        internal readonly Dictionary<K, V> data;
+
+        public DictBuilder() { this.data = []; }
+        public DictBuilder(int capacity) { this.data = new(capacity); }
+
+        public int Count => this.data.Count;
+
+        public V this[K key] {
+            get => this.data[key];
+            set => this.data[key] = value;
+        }
+
+        public void Add(K key, V value) => this.data.Add(key, value);
+
+        //public void Insert(K key, V value) => this.xs.A
+
+        //public void AddRange(IEnumerable<T> ys) => this.xs.AddRange(ys);
+    }
+
+#if NET10_0_OR_GREATER
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static ImmDict<K, V> New<K, V>(Action<DictBuilder<K, V>> fill) {
+        var dict = new DictBuilder<K, V>();
+        fill(dict);
+        return new ImmDict<K, V>(dict.data);
+    }
+
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static ImmDict<K, V> New<K, V>(int capacity, Action<DictBuilder<K, V>> fill) {
+        var dict = new DictBuilder<K, V>(capacity);
+        fill(dict);
+        return new ImmDict<K, V>(dict.data);
+    }
+#endif
+
+    public delegate void BuildDict<K, V>(DictBuilder<K, V> dict);
+
+    public static ImmDict<K, V> New<K, V>(BuildDict<K, V> fill) {
+        var dict = new DictBuilder<K, V>();
+        fill(dict);
+        return new ImmDict<K, V>(dict.data);
+    }
+
+    public static ImmDict<K, V> New<K, V>(int capacity, BuildDict<K, V> fill) {
+        var dict = new DictBuilder<K, V>(capacity);
+        fill(dict);
+        return new ImmDict<K, V>(dict.data);
+    }
 }
 
 [Serializable]

--- a/Xledger.Collections/ImmSet.cs
+++ b/Xledger.Collections/ImmSet.cs
@@ -31,52 +31,46 @@ public static class ImmSet {
 
         public bool Add(T item) => this.data.Add(item);
 
-        public void AddRange(IEnumerable<T> items) {
-            if (items is null) {
-                return;
-            }
+        public void ExceptWith(IEnumerable<T> items) =>
+            this.data.ExceptWith(items ?? []);
 
-#if NET
-            if (items is ICollection<T> coll) {
-                this.data.EnsureCapacity(this.data.Count + coll.Count);
-            } else if (items is IReadOnlyCollection<T> roColl) {
-                this.data.EnsureCapacity(this.data.Count + roColl.Count);
-            }
-#endif
+        public void IntersectWith(IEnumerable<T> items) =>
+            this.data.IntersectWith(items ?? []);
 
-            foreach (var item in items) {
-                this.data.Add(item);
-            }
-        }
+        public void UnionWith(IEnumerable<T> items) =>
+            this.data.UnionWith(items ?? []);
     }
 
 #if NET10_0_OR_GREATER
     [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-    public static ImmSet<T> New<T>(Action<SetBuilder<T>> fill) {
-        var set = new SetBuilder<T>();
-        fill(set);
-        return new ImmSet<T>(set.data);
-    }
-
-    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-    public static ImmSet<T> New<T>(int capacity, Action<SetBuilder<T>> fill) {
+    public static ImmSet<T> Build<T>(Action<SetBuilder<T>> fill,
+        int capacity = 0,
+        bool trimExcess = false
+    ) {
         var set = new SetBuilder<T>(capacity);
         fill(set);
+        if (trimExcess) {
+            set.data.TrimExcess();
+        }
         return new ImmSet<T>(set.data);
     }
 #endif
 
     public delegate void BuildSet<T>(SetBuilder<T> set);
 
-    public static ImmSet<T> New<T>(BuildSet<T> fill) {
-        var set = new SetBuilder<T>();
-        fill(set);
-        return new ImmSet<T>(set.data);
-    }
 
-    public static ImmSet<T> New<T>(int capacity, BuildSet<T> fill) {
+    /// <summary>
+    /// Safely and quickly build a new ImmSet without having to copy an existing set.
+    /// </summary>
+    /// <param name="fill">Delegate to call to build out the internal set</param>
+    /// <param name="capacity">Default capacity used to instantiate the set</param>
+    /// <param name="trimExcess">If true, TrimExcess is called.</param>
+    public static ImmSet<T> Build<T>(BuildSet<T> fill, int capacity = 0, bool trimExcess = false) {
         var set = new SetBuilder<T>(capacity);
         fill(set);
+        if (trimExcess) {
+            set.data.TrimExcess();
+        }
         return new ImmSet<T>(set.data);
     }
 }

--- a/Xledger.Collections/ImmSet.cs
+++ b/Xledger.Collections/ImmSet.cs
@@ -6,10 +6,79 @@ public static class ImmSet {
     }
 
 #if NET
+#if NET10_0_OR_GREATER
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static ImmSet<T> Of<T>(params ReadOnlySpan<T> span) {
+#else
     public static ImmSet<T> Of<T>(ReadOnlySpan<T> span) {
+#endif
         return span.ToImmSet();
     }
 #endif
+
+    public readonly ref struct SetBuilder<T> {
+        internal readonly HashSet<T> data;
+
+        public SetBuilder() { this.data = []; }
+        public SetBuilder(int capacity) { this.data = new(capacity); }
+
+        public int Count => this.data.Count;
+
+        public bool Contains(T item) => this.data.Contains(item);
+
+        public bool TryGetValue(T equalValue, out T actualValue) =>
+            this.data.TryGetValue(equalValue, out actualValue);
+
+        public bool Add(T item) => this.data.Add(item);
+
+        public void AddRange(IEnumerable<T> items) {
+            if (items is null) {
+                return;
+            }
+
+#if NET
+            if (items is ICollection<T> coll) {
+                this.data.EnsureCapacity(this.data.Count + coll.Count);
+            } else if (items is IReadOnlyCollection<T> roColl) {
+                this.data.EnsureCapacity(this.data.Count + roColl.Count);
+            }
+#endif
+
+            foreach (var item in items) {
+                this.data.Add(item);
+            }
+        }
+    }
+
+#if NET10_0_OR_GREATER
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static ImmSet<T> New<T>(Action<SetBuilder<T>> fill) {
+        var set = new SetBuilder<T>();
+        fill(set);
+        return new ImmSet<T>(set.data);
+    }
+
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+    public static ImmSet<T> New<T>(int capacity, Action<SetBuilder<T>> fill) {
+        var set = new SetBuilder<T>(capacity);
+        fill(set);
+        return new ImmSet<T>(set.data);
+    }
+#endif
+
+    public delegate void BuildSet<T>(SetBuilder<T> set);
+
+    public static ImmSet<T> New<T>(BuildSet<T> fill) {
+        var set = new SetBuilder<T>();
+        fill(set);
+        return new ImmSet<T>(set.data);
+    }
+
+    public static ImmSet<T> New<T>(int capacity, BuildSet<T> fill) {
+        var set = new SetBuilder<T>(capacity);
+        fill(set);
+        return new ImmSet<T>(set.data);
+    }
 }
 
 [Serializable]

--- a/Xledger.Collections/Xledger.Collections.csproj
+++ b/Xledger.Collections/Xledger.Collections.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Xledger.Collections</AssemblyName>
 
     <TargetFrameworks>net48;net8.0;net10.0</TargetFrameworks>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>14.0</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/Xledger.Collections/Xledger.Collections.csproj
+++ b/Xledger.Collections/Xledger.Collections.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Xledger.Collections</RootNamespace>
     <AssemblyName>Xledger.Collections</AssemblyName>
 
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net10.0</TargetFrameworks>
     <LangVersion>13.0</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>


### PR DESCRIPTION
Compile for .NET 10, prefer `params ReadOnlySpan` when possible, cleanup some method internals, use `ref struct` to allow creation of the backing collection for an ImmArray/Dict/Set without leaking any values, improves runtime perf slightly and memory pressure a little more, .NET 10 adds `allows ref struct` to `Action` so the additional delegate `Fill` types are not needed in .NET 10, but required before that.

Anyway, we can adjust the APIs however makes sense, but the structure should be solid.

<img width="912" height="169" alt="image" src="https://github.com/user-attachments/assets/1ab2f21b-9ccf-46cd-8daf-0d899746d5b6" />

```csharp
[Benchmark]
public ImmArray<string> Array_ToImmArray() {
	var arr = new string[N];
	for (int i = 0; i < arr.Length; ++i) {
		arr[i] = Guid.NewGuid().ToString();
	}
	return arr.ToImmArray();
}

[Benchmark]
public ImmArray<string> List_ToImmArray() {
	var xs = new List<string>();
	for (int i = 0; i < N; ++i) {
		xs.Add(Guid.NewGuid().ToString());
	}
	return xs.ToImmArray();
}

[Benchmark]
public ImmArray<string> ImmArray_NewSized() {
	return ImmArray.NewSized<string>(N, xs => {
		for (int i = 0; i < xs.Length; ++i) {
			xs[i] = Guid.NewGuid().ToString();
		}
	});
}
```

<img width="884" height="193" alt="image" src="https://github.com/user-attachments/assets/124134ae-b90f-4bd6-90e3-b4432cf75c58" />

```csharp
[Benchmark]
public ImmSet<string> Set0_ToImmSet() {
	var set = new HashSet<string>();
	for (int i = 0; i < N; ++i) {
		set.Add(Guid.NewGuid().ToString());
	}
	return set.ToImmSet();
}

[Benchmark]
public ImmSet<string> SetN_ToImmSet() {
	var set = new HashSet<string>(N);
	for (int i = 0; i < N; ++i) {
		set.Add(Guid.NewGuid().ToString());
	}
	return set.ToImmSet();
}


[Benchmark]
public ImmSet<string> ImmSet_New0() {
	return ImmSet.New<string>(set => {
		for (int i = 0; i < N; ++i) {
			set.Add(Guid.NewGuid().ToString());
		}
	});
}

[Benchmark]
public ImmSet<string> ImmSet_NewN() {
	return ImmSet.New<string>(N, set => {
		for (int i = 0; i < N; ++i) {
			set.Add(Guid.NewGuid().ToString());
		}
	});
}
```

<img width="899" height="194" alt="image" src="https://github.com/user-attachments/assets/9493a529-4959-4d16-b542-f9e7fac0d92c" />

```csharp
[Benchmark]
public ImmDict<string, int> Dict0_ToImmDict() {
	var dict = new Dictionary<string, int>();
	for (int i = 0; i < N; ++i) {
		dict.Add(Guid.NewGuid().ToString(), r.Next());
	}
	return dict.ToImmDict();
}

[Benchmark]
public ImmDict<string, int> DictN_ToImmDict() {
	var dict = new Dictionary<string, int>(N);
	for (int i = 0; i < N; ++i) {
		dict.Add(Guid.NewGuid().ToString(), r.Next());
	}
	return dict.ToImmDict();
}

[Benchmark]
public ImmDict<string, int> ImmDict_New0() {
	return ImmDict.New<string, int>(dict => {
		for (int i = 0; i < N; ++i) {
			dict.Add(Guid.NewGuid().ToString(), r.Next());
		}
	});
}

[Benchmark]
public ImmDict<string, int> ImmDict_NewN() {
	return ImmDict.New<string, int>(N, dict => {
		for (int i = 0; i < N; ++i) {
			dict.Add(Guid.NewGuid().ToString(), r.Next());
		}
	});
}
```