### PR TITLE
Fix API break & expand elsewhere

### DIFF
--- a/Xledger.Collections.Test/TestImmArray.cs
+++ b/Xledger.Collections.Test/TestImmArray.cs
@@ -3,14 +3,23 @@ namespace Xledger.Collections.Test;
 public class TestImmArray {
     [Fact]
     public void TestEmpty() {
+#if NET
+        var emptyCtor = typeof(ImmArray<string>).GetConstructor(
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+            []);
+        var emptyArr = (ImmArray<string>)emptyCtor.Invoke([]);
+#else
+        var emptyArr = ImmArray<string>.Empty;
+#endif
+
         var imm = ImmArray<string>.Empty;
         Assert.Empty(imm);
         Assert.Equal(0, imm.Count);
         Assert.False(imm.GetEnumerator().MoveNext());
-        Assert.Equal(imm.GetHashCode(), new ImmArray<string>().GetHashCode());
-        Assert.Equal(imm, new ImmArray<string>());
+        Assert.Equal(imm.GetHashCode(), emptyArr.GetHashCode());
+        Assert.Equal(imm, emptyArr);
         Assert.Equal(imm, imm);
-        Assert.Equal(new ImmArray<string>(), imm);
+        Assert.Equal(emptyArr, imm);
         Assert.Equal("[]", imm.ToString());
 
         Assert.False(imm.Equals((object)null));

--- a/Xledger.Collections.Test/TestImmArray.cs
+++ b/Xledger.Collections.Test/TestImmArray.cs
@@ -235,6 +235,33 @@ public class TestImmArray {
         Assert.Equal(typeof(ImmArray<ExplicitIntArray>), c.GetType());
     }
 
+
+    [Fact]
+    public void TestNew() {
+        var wArr = new object[1] { "foo", };
+        var w = new ImmArray<object>(wArr);
+        Assert.Equal(typeof(ImmArray<object>), w.GetType());
+        Assert.Equal("foo", w[0]);
+
+        var x = new ImmArray<int>(new int[] { 1 });
+        Assert.Equal(typeof(ImmArray<int>), x.GetType());
+
+        var y = new ImmArray<int>(1);
+        Assert.Equal(typeof(ImmArray<int>), y.GetType());
+
+        var z =  new ImmArray<int>((ReadOnlySpan<int>)[1]);
+        Assert.Equal(typeof(ImmArray<int>), z.GetType());
+
+        var a = new ImmArray<int[]>(new int[] { 1 });
+        Assert.Equal(typeof(ImmArray<int[]>), a.GetType());
+
+        var b = new ImmArray<ImplicitIntArray>(new ImplicitIntArray(1));
+        Assert.Equal(typeof(ImmArray<ImplicitIntArray>), b.GetType());
+
+        var c = new ImmArray<ExplicitIntArray>(new ExplicitIntArray(1));
+        Assert.Equal(typeof(ImmArray<ExplicitIntArray>), c.GetType());
+    }
+
     public record ImplicitIntArray(int i) {
         public static implicit operator int[](ImplicitIntArray arr) => [arr.i];
     }

--- a/Xledger.Collections.Test/TestImmArray.cs
+++ b/Xledger.Collections.Test/TestImmArray.cs
@@ -217,10 +217,8 @@ public class TestImmArray {
         var y = ImmArray.Of(1);
         Assert.Equal(typeof(ImmArray<int>), y.GetType());
 
-#if NET
         var z = ImmArray.Of((ReadOnlySpan<int>)[1]);
         Assert.Equal(typeof(ImmArray<int>), z.GetType());
-#endif
 
         var a = ImmArray.Of<int[]>(new int[] { 1 });
         Assert.Equal(typeof(ImmArray<int[]>), a.GetType());

--- a/Xledger.Collections.Test/TestImmArray.cs
+++ b/Xledger.Collections.Test/TestImmArray.cs
@@ -39,6 +39,11 @@ public class TestImmArray {
         Assert.Equal(imm1.GetHashCode(), imm2.GetHashCode());
         Assert.Equal(imm1, imm2);
         Assert.Equal(imm2, imm1);
+
+        ImmArray<int> imm3 = [1];
+        Assert.Equal(imm1.GetHashCode(), imm3.GetHashCode());
+        Assert.Equal(imm1, imm3);
+        Assert.Equal(imm3, imm1);
     }
 
 #if NET8_0_OR_GREATER

--- a/Xledger.Collections.Test/TestImmArray.cs
+++ b/Xledger.Collections.Test/TestImmArray.cs
@@ -246,6 +246,7 @@ public class TestImmArray {
         var x = new ImmArray<int>(new int[] { 1 });
         Assert.Equal(typeof(ImmArray<int>), x.GetType());
 
+#if NET10_0_OR_GREATER
         var y = new ImmArray<int>(1);
         Assert.Equal(typeof(ImmArray<int>), y.GetType());
 
@@ -260,6 +261,7 @@ public class TestImmArray {
 
         var c = new ImmArray<ExplicitIntArray>(new ExplicitIntArray(1));
         Assert.Equal(typeof(ImmArray<ExplicitIntArray>), c.GetType());
+#endif
     }
 
     public record ImplicitIntArray(int i) {

--- a/Xledger.Collections.Test/TestImmDict.cs
+++ b/Xledger.Collections.Test/TestImmDict.cs
@@ -3,14 +3,23 @@ namespace Xledger.Collections.Test;
 public class TestImmDict {
     [Fact]
     public void TestEmpty() {
+#if NET
+        var emptyCtor = typeof(ImmDict<string, object>).GetConstructor(
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+            []);
+        var emptyDict = (ImmDict<string, object>)emptyCtor.Invoke([]);
+#else
+        var emptyDict = ImmDict<string, object>.Empty;
+#endif
+
         var imm = ImmDict<string, object>.Empty;
         Assert.Empty(imm);
         Assert.Equal(0, imm.Count);
         Assert.False(imm.GetEnumerator().MoveNext());
-        Assert.Equal(imm.GetHashCode(), new ImmDict<string, object>().GetHashCode());
-        Assert.Equal(imm, new ImmDict<string, object>());
+        Assert.Equal(imm.GetHashCode(), emptyDict.GetHashCode());
+        Assert.Equal(imm, emptyDict);
         Assert.Equal(imm, imm);
-        Assert.Equal(new ImmDict<string, object>(), imm);
+        Assert.Equal(emptyDict, imm);
         Assert.Equal("[]", imm.ToString());
 
         Assert.False(imm.Equals((object)null));

--- a/Xledger.Collections.Test/TestImmSet.cs
+++ b/Xledger.Collections.Test/TestImmSet.cs
@@ -3,14 +3,23 @@ namespace Xledger.Collections.Test;
 public class TestImmSet{
     [Fact]
     public void TestEmpty() {
+#if NET
+        var emptyCtor = typeof(ImmSet<string>).GetConstructor(
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+            []);
+        var emptySet = (ImmSet<string>)emptyCtor.Invoke([]);
+#else
+        var emptySet = ImmSet<string>.Empty;
+#endif
+
         var imm = ImmSet<string>.Empty;
         Assert.Empty(imm);
         Assert.Equal(0, imm.Count);
         Assert.False(imm.GetEnumerator().MoveNext());
-        Assert.Equal(imm.GetHashCode(), new ImmSet<string>().GetHashCode());
-        Assert.Equal(imm, new ImmSet<string>());
+        Assert.Equal(imm.GetHashCode(), emptySet.GetHashCode());
+        Assert.Equal(imm, emptySet);
         Assert.Equal(imm, imm);
-        Assert.Equal(new ImmSet<string>(), imm);
+        Assert.Equal(emptySet, imm);
         Assert.Equal("[]", imm.ToString());
 
         Assert.False(imm.Equals((object)null));

--- a/Xledger.Collections.Test/TestImmSet.cs
+++ b/Xledger.Collections.Test/TestImmSet.cs
@@ -39,6 +39,12 @@ public class TestImmSet{
         Assert.Equal(imm1.GetHashCode(), imm2.GetHashCode());
         Assert.Equal(imm1, imm2);
         Assert.Equal(imm2, imm1);
+
+
+        var imm3 = (ImmSet<int>)[1];
+        Assert.Equal(imm1.GetHashCode(), imm3.GetHashCode());
+        Assert.Equal(imm1, imm3);
+        Assert.Equal(imm3, imm1);
     }
 
 #if NET8_0_OR_GREATER

--- a/Xledger.Collections/AssemblyInfo.cs
+++ b/Xledger.Collections/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Xledger.Collections.Bench")]
-[assembly: InternalsVisibleTo("Xledger.Collections.Test")]
 [assembly: InternalsVisibleTo("LINQPadQuery")]

--- a/Xledger.Collections/Extensions.cs
+++ b/Xledger.Collections/Extensions.cs
@@ -22,11 +22,9 @@ public static class Extensions {
         };
     }
 
-#if NET
     public static ImmArray<T> ToImmArray<T>(this ReadOnlySpan<T> xs) {
         return new ImmArray<T>(xs.ToArray());
     }
-#endif
 
     public static ImmArray<T> ToImmArray<T>(this Span<T> xs) {
         return new ImmArray<T>(xs.ToArray());
@@ -47,7 +45,6 @@ public static class Extensions {
         };
     }
 
-#if NET
     public static ImmSet<T> ToImmSet<T>(this ReadOnlySpan<T> xs) {
         var set = new HashSet<T>(xs.Length);
         foreach (var x in xs) {
@@ -55,7 +52,6 @@ public static class Extensions {
         }
         return new ImmSet<T>(set);
     }
-#endif
 
     public static ImmSet<T> ToImmSet<T>(this Span<T> xs) {
         var set = new HashSet<T>(xs.Length);

--- a/Xledger.Collections/ImmArray.cs
+++ b/Xledger.Collections/ImmArray.cs
@@ -5,7 +5,6 @@ public static class ImmArray {
         return arr.ToImmArray();
     }
 
-#if NET
 #if NET10_0_OR_GREATER
     [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public static ImmArray<T> Of<T>(params ReadOnlySpan<T> span) {
@@ -14,7 +13,6 @@ public static class ImmArray {
 #endif
         return new ImmArray<T>(span);
     }
-#endif
 
 #if NET10_0_OR_GREATER
     [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]

--- a/Xledger.Collections/ImmArray.cs
+++ b/Xledger.Collections/ImmArray.cs
@@ -8,10 +8,11 @@ public static class ImmArray {
 #if NET10_0_OR_GREATER
     [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public static ImmArray<T> Of<T>(params ReadOnlySpan<T> span) {
+        return new ImmArray<T>(span);
 #else
     public static ImmArray<T> Of<T>(ReadOnlySpan<T> span) {
+        return new ImmArray<T>(span.ToArray());
 #endif
-        return new ImmArray<T>(span);
     }
 
 #if NET10_0_OR_GREATER
@@ -73,12 +74,14 @@ public sealed class ImmArray<T> : IReadOnlyList<T>, IEquatable<ImmArray<T>>, ILi
         }
     }
 
+#if NET10_0_OR_GREATER
     /// <summary>
     /// Constructs an ImmArray by copying the span's contents.
     /// </summary>
     public ImmArray(params ReadOnlySpan<T> data) {
         this.data = data.ToArray();
     }
+#endif
 
     public ReadOnlySpan<T> Span => this.data;
 

--- a/Xledger.Collections/ImmArray.cs
+++ b/Xledger.Collections/ImmArray.cs
@@ -35,9 +35,7 @@ public static class ImmArray {
 [Serializable]
 [DebuggerDisplay("Count = {Count}")]
 [DebuggerTypeProxy(typeof(ImmArray<>.DebugView))]
-#if NET8_0_OR_GREATER
 [System.Runtime.CompilerServices.CollectionBuilder(typeof(ImmArray), nameof(ImmArray.Of))]
-#endif
 public sealed class ImmArray<T> : IReadOnlyList<T>, IEquatable<ImmArray<T>>, IList<T>,
     ICollection, IComparable, IComparable<ImmArray<T>>, IStructuralComparable
 {

--- a/Xledger.Collections/ImmSet.cs
+++ b/Xledger.Collections/ImmSet.cs
@@ -5,7 +5,6 @@ public static class ImmSet {
         return arr.ToImmSet();
     }
 
-#if NET
 #if NET10_0_OR_GREATER
     [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public static ImmSet<T> Of<T>(params ReadOnlySpan<T> span) {
@@ -14,7 +13,6 @@ public static class ImmSet {
 #endif
         return span.ToImmSet();
     }
-#endif
 
     public readonly ref struct SetBuilder<T> {
         internal readonly HashSet<T> data;

--- a/Xledger.Collections/ImmSet.cs
+++ b/Xledger.Collections/ImmSet.cs
@@ -76,9 +76,7 @@ public static class ImmSet {
 [Serializable]
 [DebuggerDisplay("Count = {Count}")]
 [DebuggerTypeProxy(typeof(ImmSet<>.DebugView))]
-#if NET8_0_OR_GREATER
-[System.Runtime.CompilerServices.CollectionBuilder(typeof(ImmSet), nameof(ImmArray.Of))]
-#endif
+[System.Runtime.CompilerServices.CollectionBuilder(typeof(ImmSet), nameof(ImmSet.Of))]
 public sealed class ImmSet<T> : IReadOnlyCollection<T>, ISet<T>, IEquatable<ImmSet<T>>, ICollection
 #if NET6_0_OR_GREATER
     , IReadOnlySet<T>

--- a/Xledger.Collections/Polyfills/CollectionBuilderAttribute.cs
+++ b/Xledger.Collections/Polyfills/CollectionBuilderAttribute.cs
@@ -1,0 +1,31 @@
+#if NETFRAMEWORK
+namespace System.Runtime.CompilerServices {
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, Inherited = false)]
+    public sealed class CollectionBuilderAttribute : Attribute {
+        //
+        // Summary:
+        //     Initializes a new instance of System.Runtime.CompilerServices.CollectionBuilderAttribute
+        //     that refers to the methodName method on the builderType type.
+        //
+        // Parameters:
+        //   builderType:
+        //     The type of the builder to use to construct the collection.
+        //
+        //   methodName:
+        //     The name of the method on the builder to use to construct the collection.
+        public CollectionBuilderAttribute(Type builderType, string methodName) {
+            this.BuilderType = builderType;
+            this.MethodName = methodName;
+        }
+
+        //
+        // Summary:
+        //     Gets the type of the builder to use to construct the collection.
+        public Type BuilderType { get; }
+        //
+        // Summary:
+        //     Gets the name of the method on the builder to use to construct the collection.
+        public string MethodName { get; }
+    }
+}
+#endif


### PR DESCRIPTION
This does 4 different things. Any of which can be rejected without affecting the others (except that 3 depends on 2):

1. Change [Xledger.Collections.Test tests via public API & reflection](https://github.com/xledger/Xledger.Collections/commit/30d68116300cc49cad535cfae604c0ae2c777bb8) rather than having internal access. This changes how resolution of internal vs public is handled to more closely match third-party users of the library.
2. [Support ReadOnlySpan on .NET 48.](https://github.com/xledger/Xledger.Collections/commit/6a8e9cc6f58966a36cc72d7947d37289ca488b66) - which is why the .NET 48 version of this package depends on System.Memory. 
3. [Support collection expressions on .NET 48.](https://github.com/xledger/Xledger.Collections/commit/e3ac40f3b2842ae836d9ff80ddd7df0667beb134) - by implementing the single attribute polyfill that the compiler needs to specify the correct builder method.
4. [Test new ImmArray construction.](https://github.com/xledger/Xledger.Collections/commit/73334283c1e8c46a470880533e90288cafe04d22) - since there is a breaking change in the API between 0.8.0 and 0.9.0 in C# 12 (tho not in C# 14).
5. [Remove new ImmArray<T>(params ReadOnlySpan<T>) to revert API break.](https://github.com/xledger/Xledger.Collections/pull/17/commits/3d8a16b73e2a4c24f6237e76a8d74b8609916eee)

